### PR TITLE
chore: updates for jvm23

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,6 @@ THE POSSIBILITY OF SUCH DAMAGE.
             <groupId>org.openjdk.jmh</groupId>
             <artifactId>jmh-generator-annprocess</artifactId>
             <version>${jmh.version}</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>net.java.dev.jna</groupId>
@@ -86,12 +85,12 @@ THE POSSIBILITY OF SUCH DAMAGE.
         <!--
             JMH version to use with this project.
           -->
-        <jmh.version>1.36</jmh.version>
+        <jmh.version>1.37</jmh.version>
 
         <!--
             Java source/target to use for compilation.
           -->
-        <javac.target>21</javac.target>
+        <javac.target>23</javac.target>
 
         <!--
             Name of the benchmark Uber-JAR to generate.
@@ -109,6 +108,13 @@ THE POSSIBILITY OF SUCH DAMAGE.
                     <compilerVersion>${javac.target}</compilerVersion>
                     <source>${javac.target}</source>
                     <target>${javac.target}</target>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.openjdk.jmh</groupId>
+                            <artifactId>jmh-generator-annprocess</artifactId>
+                            <version>${jmh.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
                     <!-- release>${javac.target}</release -->
                     <compilerArgs>
                         <arg>--enable-preview</arg>

--- a/run.sh
+++ b/run.sh
@@ -46,6 +46,8 @@ elif [ "$JIT_COMPILER" == "NONE" ]; then
   java_options+=(-Xint)
 fi
 
+set -x
+
 $JAVA_HOME/bin/java \
   "${java_options[@]}" \
   -jar "$BENCHMARK_DIR/target/benchmarks.jar" \

--- a/src/main/java/benchmark/Helper.java
+++ b/src/main/java/benchmark/Helper.java
@@ -31,15 +31,20 @@
 
 package benchmark;
 
-import com.sun.jna.Native;
-import jnr.ffi.LibraryLoader;
-import jnr.ffi.LibraryOption;
-import sun.misc.Unsafe;
-
-import java.lang.foreign.*;
+import java.lang.foreign.Arena;
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.Linker;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.SymbolLookup;
 import java.lang.invoke.MethodHandle;
 import java.lang.reflect.Field;
 import java.util.Map;
+
+import com.sun.jna.Native;
+
+import jnr.ffi.LibraryLoader;
+import jnr.ffi.LibraryOption;
+import sun.misc.Unsafe;
 
 public class Helper {
 
@@ -59,7 +64,7 @@ public class Helper {
         }
     }
 
-    private static final Linker.Option[] TRIVIAL = {Linker.Option.isTrivial()};
+    private static final Linker.Option[] TRIVIAL = {Linker.Option.critical(true)};
     private static final Linker.Option[] NOT_TRIVIAL = {};
 
     static MethodHandle downcallHandle(String name, FunctionDescriptor fd, boolean trivial) {

--- a/src/main/java/benchmark/QSortBenchmark.java
+++ b/src/main/java/benchmark/QSortBenchmark.java
@@ -2,11 +2,14 @@ package benchmark;
 
 import com.sun.jna.Callback;
 import com.sun.jna.Library;
+
 import jnr.ffi.annotations.Delegate;
+
 import org.openjdk.jmh.annotations.*;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -14,6 +17,7 @@ import java.lang.invoke.MethodType;
 
 import static benchmark.Helper.UNSAFE;
 import static benchmark.Helper.downcallHandle;
+
 import static java.lang.foreign.ValueLayout.*;
 
 @State(Scope.Benchmark)
@@ -97,7 +101,7 @@ public class QSortBenchmark {
     public void setup() {
         benchmarkArena = Arena.ofConfined();
 
-        segment = benchmarkArena.allocateArray(JAVA_INT, length);
+        segment = benchmarkArena.allocate(MemoryLayout.sequenceLayout(length, JAVA_INT));
         for (int i = 0; i < length; i++) {
             segment.set(JAVA_INT, i * 4L, i);
         }

--- a/src/main/java/benchmark/StringConvertBenchmark.java
+++ b/src/main/java/benchmark/StringConvertBenchmark.java
@@ -1,6 +1,7 @@
 package benchmark;
 
 import benchmark.experimental.GetStringUTF8Benchmark;
+
 import com.sun.jna.Library;
 import org.openjdk.jmh.annotations.*;
 
@@ -9,6 +10,7 @@ import java.lang.foreign.FunctionDescriptor;
 import java.lang.foreign.MemorySegment;
 import java.lang.invoke.MethodHandle;
 import java.util.function.Consumer;
+import java.nio.charset.StandardCharsets;
 
 import static benchmark.Helper.downcallHandle;
 import static java.lang.foreign.ValueLayout.ADDRESS;
@@ -85,14 +87,14 @@ public class StringConvertBenchmark {
     @Benchmark
     public void passStringToNativePanama() throws Throwable {
         try (Arena arena = Arena.ofConfined()) {
-            acceptString.invokeExact(arena.allocateUtf8String(testString));
+            acceptString.invokeExact(arena.allocateFrom(testString, StandardCharsets.UTF_8));
         }
     }
 
     @Benchmark
     public void passStringToNativePanamaTrivial() throws Throwable {
         try (Arena arena = Arena.ofConfined()) {
-            acceptStringTrivial.invokeExact(arena.allocateUtf8String(testString));
+            acceptStringTrivial.invokeExact(arena.allocateFrom(testString, StandardCharsets.UTF_8));
         }
     }
 
@@ -123,12 +125,12 @@ public class StringConvertBenchmark {
 
     @Benchmark
     public String getStringFromNativePanama() throws Throwable {
-        return ((MemorySegment) getString.invokeExact(length)).reinterpret(Long.MAX_VALUE).getUtf8String(0);
+        return ((MemorySegment) getString.invokeExact(length)).reinterpret(Long.MAX_VALUE).getString(0, StandardCharsets.UTF_8);
     }
 
     @Benchmark
     public String getStringFromNativePanamaTrivial() throws Throwable {
-        return ((MemorySegment) getStringTrivial.invokeExact(length)).reinterpret(Long.MAX_VALUE).getUtf8String(0);
+        return ((MemorySegment) getStringTrivial.invokeExact(length)).reinterpret(Long.MAX_VALUE).getString(0, StandardCharsets.UTF_8);
     }
 
     @Benchmark

--- a/src/main/java/benchmark/SysinfoBenchmark.java
+++ b/src/main/java/benchmark/SysinfoBenchmark.java
@@ -1,15 +1,25 @@
 package benchmark;
 
-import benchmark.experimental.NativeStack;
-import com.sun.jna.Library;
-import com.sun.jna.platform.linux.LibC;
-import jnr.ffi.annotations.Out;
-import org.openjdk.jmh.annotations.*;
-
-import java.lang.foreign.*;
+import java.lang.foreign.Arena;
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.MemoryLayout;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.VarHandle;
 import java.util.function.Consumer;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+
+import com.sun.jna.Library;
+import com.sun.jna.platform.linux.LibC;
+
+import benchmark.experimental.NativeStack;
+import jnr.ffi.annotations.Out;
 
 @State(Scope.Benchmark)
 public class SysinfoBenchmark {
@@ -23,9 +33,9 @@ public class SysinfoBenchmark {
             ValueLayout.JAVA_LONG.withName("bufferram"),
             ValueLayout.JAVA_LONG.withName("totalswap"),
             ValueLayout.JAVA_LONG.withName("freeswap"),
-            ValueLayout.JAVA_SHORT.withName("procs").withBitAlignment(64),
+            ValueLayout.JAVA_SHORT.withName("procs").withByteAlignment(8),
             MemoryLayout.paddingLayout(48),
-            ValueLayout.JAVA_LONG.withName("totalhigh").withBitAlignment(64),
+            ValueLayout.JAVA_LONG.withName("totalhigh").withByteAlignment(8),
             ValueLayout.JAVA_LONG.withName("freehigh"),
             ValueLayout.JAVA_INT.withName("mem_unit"),
             MemoryLayout.paddingLayout(32).withName("_f")

--- a/src/main/java/benchmark/experimental/GetStringUTF8Benchmark.java
+++ b/src/main/java/benchmark/experimental/GetStringUTF8Benchmark.java
@@ -1,8 +1,5 @@
 package benchmark.experimental;
 
-import jdk.incubator.vector.*;
-import org.openjdk.jmh.annotations.*;
-
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
@@ -13,6 +10,16 @@ import java.lang.invoke.MethodType;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+
+import jdk.incubator.vector.ByteVector;
+import jdk.incubator.vector.VectorOperators;
+import jdk.incubator.vector.VectorSpecies;
 
 @State(Scope.Benchmark)
 public class GetStringUTF8Benchmark {
@@ -88,7 +95,7 @@ public class GetStringUTF8Benchmark {
     public static String getUtf8String(MemorySegment segment) {
         long length = segment.byteSize();
         if (segment.address() % SPECIES_LENGTH != 0) { // For simplicity, do not handle these situations
-            return segment.getUtf8String(0);
+            return segment.getString(0, StandardCharsets.UTF_8);
         }
 
         int len = strlen(segment, (int) Long.min(length, Integer.MAX_VALUE));
@@ -114,7 +121,7 @@ public class GetStringUTF8Benchmark {
 
         MemorySegment heapSegment = MemorySegment.ofArray(bytes);
         MemorySegment res = arena.allocate(MemoryLayout.sequenceLayout(bytes.length + 1, ValueLayout.JAVA_BYTE)
-                .withBitAlignment((long) SPECIES_LENGTH * Byte.SIZE));
+                .withByteAlignment((long) SPECIES_LENGTH));
 
         if (res.address() % SPECIES_LENGTH != 0) {
             throw new AssertionError();
@@ -163,7 +170,7 @@ public class GetStringUTF8Benchmark {
 
     //@Benchmark
     public String panama() {
-        return segment.getUtf8String(0);
+        return segment.getString(0, StandardCharsets.UTF_8);
     }
 
     //@Benchmark


### PR DESCRIPTION
## Summary

Hi @Glavo! Thank you for preparing this project. I wanted to see how Panama performance has changed with newer releases of GraalVM, so I updated this on my fork to work up to the latest release version (JDK23 at the time of this writing).

I am planning to use [JMH Visualizer](https://jmh.morethan.io/) to produce new images, unless there is a faster way. Maybe I can also produce a JSON file for your original benchmarks so we can compare, but I'm on different hardware anyway (I can provide updated JVM 21 benchmarks on my machine to keep them consistent, if you are open to it).

I am also planning to test EA releases for GVM 24 and GVM 25 as well as `native-image` once I get some time. I am happy to offer all of the above back upstream to your fork, if you are interested. Just let me know.

In the meantime, these changes get things working with JVM 23, along with some other edits.

### Changelog

- [x] Bump JMH to latest
- [x] Bump JVM targeting to JVM 23
- [x] Nits: My IDE sorted imports, and `provided` was removed from the JMH annotation processor
- [x] Breakage fixes for latest Panama preview APIs
  - [x] `withBitAlignment(...)` → `withByteAlignment(...)`
    - **Rationale**: [`withBitAlignment`](https://cr.openjdk.org/~pminborg/panama/21/v1/javadoc/java.base/java/lang/foreign/ValueLayout.html#withBitAlignment(long)) became [`withByteAlignment`](https://docs.oracle.com/en/java/javase/23/docs/api/java.base/java/lang/foreign/ValueLayout.html#withByteAlignment(long)), which accepts an alignment expressed in bytes.
  - [x] `Linker.Option.isTrivial()` → `Linker.Option.critical(false)`
    - **Rationale:** [`isTrivial`](https://cr.openjdk.org/~pminborg/panama/21/v1/javadoc/java.base/java/lang/foreign/Linker.Option.html#isTrivial()) was conceptually merged with "critical JNI" to become [`critical(...)`](https://docs.oracle.com/en/java/javase/23/docs/api/java.base/java/lang/foreign/Linker.Option.html) (I think?).
  - [x] `allocateArray(JAVA_INT, length)` → `allocate(sequenceLayout(length, JAVA_INT))`
    - **Rationale:** [`allocateArray`](https://cr.openjdk.org/~pminborg/panama/21/v1/javadoc/java.base/java/lang/foreign/SegmentAllocator.html#allocateArray(java.lang.foreign.MemoryLayout,long)) was removed; the docs reveal equivalence with `allocate(sequenceLayout(...))` anyway, which has become [`allocateFrom(sequenceLayout(...), ...)`](https://docs.oracle.com/en/java/javase/23/docs/api/java.base/java/lang/foreign/SegmentAllocator.html#allocateFrom(java.lang.foreign.AddressLayout,java.lang.foreign.MemorySegment)).
  - [x] `arena.allocateUtf8String(testString)` → `arena.allocateFrom(testString, StandardCharsets.UTF_8)`
    - **Rationale:** [`allocateUtf8String(testString)`](https://cr.openjdk.org/~pminborg/panama/21/v1/javadoc/java.base/java/lang/foreign/SegmentAllocator.html#allocateUtf8String(java.lang.String)) no longer exists; it has become [`allocateFrom(testString)`](https://docs.oracle.com/en/java/javase/23/docs/api/java.base/java/lang/foreign/SegmentAllocator.html#allocateFrom(java.lang.String)).
  - [x] `getUtf8String(0)` → `getString(0, StandardCharsets.UTF_8)`
    - **Rationale:** [`getUtf8String(...)`](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/foreign/MemorySegment.html#getUtf8String(long)) no longer exists; it has become [`getString(...)`](https://docs.oracle.com/en/java/javase/23/docs/api/java.base/java/lang/foreign/MemorySegment.html#getString(long)).